### PR TITLE
Fdk init

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@ This repository contains scripts that demonstrate the usage of [MBIRJAX](https:/
    ```
    git clone git@github.com:cabouman/mbirjax_applications.git
    ```
-3. Run demo scripts for the application of your choice. Availble applications include:
+3. Run demo scripts for the application of your choice. Note that if you do not have a GPU with cuda, 
+then replace `pip install mbirjax[cuda12]` with `pip install mbirjax`
+
+Available applications include:
    * Cone-beam CT reconstruction with NorthStar Instrument (NSI) system:
      ```
-     pip install mbirjax
+     pip install mbirjax[cuda12]
      cd mbirjax_applications/nsi
      python demo_nsi.py
      ```
    * NERSC:
      ```
-     pip install mbirjax
+     pip install mbirjax[cuda12]
      cd mbirjax_applications/nersc
      python demo_nersc.py
      ```

--- a/nsi/demo_nsi.py
+++ b/nsi/demo_nsi.py
@@ -76,7 +76,11 @@ if __name__ == "__main__":
 
     time0 = time.time()
     # Using FDK reconstruction as initialization of VCD
+    print('Starting fdk')
     fdk_recon = ct_model.fdk_recon(sino)
+    elapsed = time.time() - time0
+    print('Elapsed time for fdk is {:.3f} seconds'.format(elapsed))
+    time0 = time.time()
     recon, recon_params = ct_model.recon(sino, weights=weights, init_recon=fdk_recon)
     recon.block_until_ready()
     elapsed = time.time() - time0

--- a/nsi/demo_nsi.py
+++ b/nsi/demo_nsi.py
@@ -73,10 +73,11 @@ if __name__ == "__main__":
           "\n*******************************************************")
     # ##########################
     # Perform VCD reconstruction
+
     time0 = time.time()
-
-    recon, recon_params = ct_model.recon(sino, weights=weights)
-
+    # Using FDK reconstruction as initialization of VCD
+    fdk_recon = ct_model.fdk_recon(sino)
+    recon, recon_params = ct_model.recon(sino, weights=weights, init_recon=fdk_recon)
     recon.block_until_ready()
     elapsed = time.time() - time0
     print('Elapsed time for recon is {:.3f} seconds'.format(elapsed))


### PR DESCRIPTION
Include the use of fdk to create an initial recon prior to calling vcd recon.  This produces faster convergence to the final reconstruction.  